### PR TITLE
NetBeans Integration

### DIFF
--- a/default/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/default/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,6 +29,7 @@
         <include>Info.plist.xml</include>
         <include>robovm.xml</include>
         <include>robovm.properties</include>
+        <include>nbactions.xml</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/default/src/main/resources/archetype-resources/nbactions.xml
+++ b/default/src/main/resources/archetype-resources/nbactions.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+    <action>
+        <actionName>run</actionName>
+        <goals>
+            <goal>package</goal>
+            <goal>robovm:ipad-sim</goal>
+        </goals>
+        <properties>
+            <skipTests>true</skipTests>
+        </properties>
+    </action>
+    <action>
+        <actionName>debug</actionName>
+        <goals>
+            <goal>package</goal>
+            <goal>robovm:ipad-sim</goal>
+        </goals>
+        <properties>
+            <jpda.listen>true</jpda.listen>
+            <skipTests>true</skipTests>
+            <!-- this is so far just assumed syntax -->
+            <robovm.debug>listen</robovm.debug>
+            <robovm.debugPort>${jpda.address}</robovm.debugPort>
+        </properties>
+    </action>
+    <action>
+        <actionName>CUSTOM-ipad-sim</actionName>
+        <displayName>Run in iPad Simulator</displayName>
+        <goals>
+            <goal>package</goal>
+            <goal>robovm:ipad-sim</goal>
+        </goals>
+        <properties>
+            <skipTests>true</skipTests>
+        </properties>
+    </action>
+    <action>
+        <actionName>CUSTOM-iphone-sim</actionName>
+        <displayName>Run in iPhone Simulator</displayName>
+        <goals>
+            <goal>package</goal>
+            <goal>robovm:iphone-sim</goal>
+        </goals>
+        <properties>
+            <skipTests>true</skipTests>
+        </properties>
+    </action>
+    <action>
+        <actionName>CUSTOM-ios-device</actionName>
+        <displayName>Run on iOS Device</displayName>
+        <goals>
+            <goal>package</goal>
+            <goal>robovm:ios-device</goal>
+        </goals>
+        <properties>
+            <skipTests>true</skipTests>
+        </properties>
+    </action>
+    <action>
+        <actionName>CUSTOM-create-ipa</actionName>
+        <displayName>Create iOS Package Archive</displayName>
+        <goals>
+            <goal>clean</goal>
+            <goal>package</goal>
+            <goal>robovm:create-ipa</goal>
+        </goals>
+    </action>
+</actions>


### PR DESCRIPTION
Generated archetype includes nbactions.xml which is enough to tell NetBeans how to run the application (in iPad simulator), to debug it (possibly incorrect, depends on developments in RoboVM debug:clientmode) and offers other custom commands (run in iPhone, on device, create IPA).

Verified by running 

``` bash
$ mvn archetype:generate \
  -DarchetypeGroupId=org.robovm \
  -DarchetypeArtifactId=robovm-default-template \
  -DarchetypeVersion=1.0.1-SNAPSHOT \
  -DgroupId=org.apidesign.test \
  -DartifactId=abc -Dversion=0.3-SNAPSHOT
```

..opening the generated project in NetBeans and invoking Run on it.
